### PR TITLE
[UPDATE] Removed jekyll deprecation warning. Update github-pages gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ source 'https://rubygems.org'
 require 'open-uri'
 # versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 versions = {}
-versions['github-pages'] = '183'
+versions['github-pages'] = '226'
 
 gem 'github-pages', versions['github-pages']
-# This are auto included by github-pages gem. No need to mention them
+# These are auto included by github-pages gem. No need to mention them
 # gem 'jekyll'
 # gem 'kramdown'
 


### PR DESCRIPTION
- Removed deprecation warnings related to jekyll.
   - `jekyll/document.rb:449: warning: Using the last argument as keyword parameters is deprecated`