### PR TITLE
[UPDATE] GA4 ID 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,8 +30,8 @@ owner:
 
 
 # Analytics and webmaster tools stuff goes here
-google_analytics: 'UA-707704-1'
-google_analytics_tag: 'G-CB7H9KN61P'
+google_analytics: 'G-N2P95C00QP'
+google_analytics_tag: 'G-N2P95C00QP'
 google_verify:
 # https://ssl.bing.com/webmaster/configure/verify/ownership Option 2 content= goes here
 bing_verify:

--- a/_devconfig.yml
+++ b/_devconfig.yml
@@ -30,8 +30,8 @@ owner:
 
 
 # Analytics and webmaster tools stuff goes here
-google_analytics: 'UA-707704-1'
-google_analytics_tag: 'G-CB7H9KN61P'
+google_analytics: 'G-N2P95C00QP'
+google_analytics_tag: 'G-N2P95C00QP'
 google_verify:
 # https://ssl.bing.com/webmaster/configure/verify/ownership Option 2 content= goes here
 bing_verify:


### PR DESCRIPTION
### Describe the Problem
We need to separate the tracking for the blog from elitmus.com. So, we can keep track of the blog site performance. 

### Solution
- Added new GA4 ID in the `_devconfig.yml` and `_config.yml`
- we don't need the UA ID now